### PR TITLE
more git filters and notification center initialization for Windows OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ __astcache/
 
 # Boss dependency manager vendor folder https://github.com/HashLoad/boss
 modules/
+
+# Mac Finder and Windows Explorer files
+.DS_Store
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,13 @@ modules/
 # Mac Finder and Windows Explorer files
 .DS_Store
 Thumbs.db
+
+# Default Delphi compiler directories
+Win32/
+Win64/
+OSX64/
+OSXARM64/
+Android/
+Android64/
+iOSDevice64/
+Linux64/

--- a/Object Pascal/Mobile Snippets/Notifications/SendCancelNotification/uMain.fmx
+++ b/Object Pascal/Mobile Snippets/Notifications/SendCancelNotification/uMain.fmx
@@ -6,6 +6,7 @@ object NotificationsForm: TNotificationsForm
   FormFactor.Width = 1920
   FormFactor.Height = 1022
   FormFactor.Devices = [Desktop]
+  OnCreate = FormCreate
   DesignerMasterStyle = 2
   object btnSendScheduledNotification: TButton
     Action = ActionSendScheduledNotification

--- a/Object Pascal/Mobile Snippets/Notifications/SendCancelNotification/uMain.pas
+++ b/Object Pascal/Mobile Snippets/Notifications/SendCancelNotification/uMain.pas
@@ -1,4 +1,4 @@
-//---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Copyright (c) 2016 Embarcadero Technologies, Inc. All rights reserved.
 //
 // This software is the copyrighted property of Embarcadero Technologies, Inc.
@@ -10,14 +10,14 @@
 // as such term is defined thereunder. Your use of this software constitutes
 // your acknowledgement of your agreement to the foregoing software license
 // and support agreement.
-//---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 unit uMain;
 
 interface
 
 uses
   System.Actions, System.Classes, System.Notification,
-  FMX.ActnList, FMX.Controls, FMX.Controls.Presentation, FMX.Forms, FMX.Memo, 
+  FMX.ActnList, FMX.Controls, FMX.Controls.Presentation, FMX.Forms, FMX.Memo,
   FMX.Memo.Types, FMX.ScrollBox, FMX.StdCtrls, FMX.Types;
 
 type
@@ -37,13 +37,16 @@ type
     ActionCancelScheduled: TAction;
     ActionCancelAllNotifications: TAction;
 
-    procedure NotificationCPermissionRequestResult(Sender: TObject; const AIsGranted: Boolean);
-    procedure NotificationCReceiveLocalNotification(Sender: TObject; ANotification: TNotification);
+    procedure NotificationCPermissionRequestResult(Sender: TObject;
+      const AIsGranted: Boolean);
+    procedure NotificationCReceiveLocalNotification(Sender: TObject;
+      ANotification: TNotification);
     procedure ActionListExecute(Action: TBasicAction; var Handled: Boolean);
     procedure ActionSendScheduledNotificationExecute(Sender: TObject);
     procedure ActionSendNotificationImmediatelyExecute(Sender: TObject);
     procedure ActionCancelScheduledExecute(Sender: TObject);
     procedure ActionCancelAllNotificationsExecute(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
     FPendingAction: TBasicAction;
   end;
@@ -57,8 +60,9 @@ implementation
 
 uses
   System.SysUtils;
-  
-procedure TNotificationsForm.NotificationCPermissionRequestResult(Sender: TObject; const AIsGranted: Boolean);
+
+procedure TNotificationsForm.NotificationCPermissionRequestResult
+  (Sender: TObject; const AIsGranted: Boolean);
 begin
   if AIsGranted and (FPendingAction <> nil) then
   begin
@@ -68,12 +72,14 @@ begin
   FPendingAction := nil;
 end;
 
-procedure TNotificationsForm.NotificationCReceiveLocalNotification(Sender: TObject; ANotification: TNotification);
+procedure TNotificationsForm.NotificationCReceiveLocalNotification
+  (Sender: TObject; ANotification: TNotification);
 begin
   Memo1.Lines.Add(ANotification.AlertBody);
 end;
 
-procedure TNotificationsForm.ActionListExecute(Action: TBasicAction; var Handled: Boolean);
+procedure TNotificationsForm.ActionListExecute(Action: TBasicAction;
+  var Handled: Boolean);
 begin
   if NotificationC.AuthorizationStatus <> TAuthorizationStatus.Authorized then
   begin
@@ -84,9 +90,11 @@ begin
   end;
 end;
 
-procedure TNotificationsForm.ActionSendScheduledNotificationExecute(Sender: TObject);
+procedure TNotificationsForm.ActionSendScheduledNotificationExecute
+  (Sender: TObject);
 begin
-  var Notification := NotificationC.CreateNotification;
+  var
+  Notification := NotificationC.CreateNotification;
   try
     Notification.Name := 'MyNotification';
     Notification.AlertBody := 'Delphi for Mobile is here!';
@@ -100,9 +108,21 @@ begin
   end;
 end;
 
-procedure TNotificationsForm.ActionSendNotificationImmediatelyExecute(Sender: TObject);
+procedure TNotificationsForm.FormCreate(Sender: TObject);
 begin
-  var Notification := NotificationC.CreateNotification;
+{$IFDEF MSWINDOWS}
+  // Windows needs a delay (some seconds) between initialization and presenting
+  // a notification to have the good title in first notification displayed in
+  // the life of a program
+  NotificationC.PlatformInitialize;
+{$ENDIF}
+end;
+
+procedure TNotificationsForm.ActionSendNotificationImmediatelyExecute
+  (Sender: TObject);
+begin
+  var
+  Notification := NotificationC.CreateNotification;
   try
     Notification.AlertBody := 'Delphi for Mobile is here!';
     Notification.FireDate := Now;
@@ -120,7 +140,8 @@ begin
   NotificationC.CancelNotification('MyNotification');
 end;
 
-procedure TNotificationsForm.ActionCancelAllNotificationsExecute(Sender: TObject);
+procedure TNotificationsForm.ActionCancelAllNotificationsExecute
+  (Sender: TObject);
 begin
   NotificationC.CancelAll;
 end;

--- a/Object Pascal/Multi-Device Samples/Device Sensors and Services/Windows 10 Notifications/NotificationsForm.fmx
+++ b/Object Pascal/Multi-Device Samples/Device Sensors and Services/Windows 10 Notifications/NotificationsForm.fmx
@@ -9,6 +9,7 @@ object Notify: TNotify
   FormFactor.Height = 480
   FormFactor.Devices = [Desktop]
   ShowHint = False
+  OnCreate = FormCreate
   OnShow = FormShow
   DesignerMasterStyle = 0
   object btnShow: TButton

--- a/Object Pascal/Multi-Device Samples/Device Sensors and Services/Windows 10 Notifications/NotificationsForm.pas
+++ b/Object Pascal/Multi-Device Samples/Device Sensors and Services/Windows 10 Notifications/NotificationsForm.pas
@@ -1,4 +1,4 @@
-//---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 
 // This software is Copyright (c) 2015 Embarcadero Technologies, Inc.
 // You may only use this software if you are an authorized licensee
@@ -7,16 +7,18 @@
 // the software license agreement that comes with the Embarcadero Products
 // and is subject to that software license agreement.
 
-//---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 
 unit NotificationsForm;
 
 interface
 
 uses
-  System.SysUtils, System.Types, System.UITypes, System.Classes, System.Variants,
-  FMX.Types, FMX.Controls, FMX.Forms, FMX.Graphics, FMX.Dialogs, FMX.Controls.Presentation, FMX.StdCtrls,
-  System.Notification, FMX.ScrollBox, FMX.Memo;
+  System.SysUtils, System.Types, System.UITypes, System.Classes,
+  System.Variants,
+  FMX.Types, FMX.Controls, FMX.Forms, FMX.Graphics, FMX.Dialogs,
+  FMX.Controls.Presentation, FMX.StdCtrls,
+  System.Notification, FMX.ScrollBox, FMX.Memo, FMX.Memo.Types;
 
 type
   TNotify = class(TForm)
@@ -30,15 +32,17 @@ type
     lblLog: TLabel;
     StyleBook1: TStyleBook;
     procedure btnShowClick(Sender: TObject);
-    procedure NotificationCenter1ReceiveLocalNotification(Sender: TObject; ANotification: TNotification);
+    procedure NotificationCenter1ReceiveLocalNotification(Sender: TObject;
+      ANotification: TNotification);
     procedure btnCancelAllClick(Sender: TObject);
     procedure btnShowAnotherClick(Sender: TObject);
     procedure btnCancelClick(Sender: TObject);
     procedure btnCancelAnotherClick(Sender: TObject);
     procedure FormShow(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
     { Private declarations }
-    //FNotificationCenter: TNotificationCenter;
+    // FNotificationCenter: TNotificationCenter;
   public
     { Public declarations }
   end;
@@ -66,13 +70,24 @@ begin
   end;
 end;
 
+procedure TNotify.FormCreate(Sender: TObject);
+begin
+{$IFDEF MSWINDOWS}
+  // Windows needs a delay (some seconds) between initialization and presenting
+  // a notification to have the good title in first notification displayed in
+  // the life of a program
+  NotificationCenter1.PlatformInitialize;
+{$ENDIF}
+end;
+
 procedure TNotify.FormShow(Sender: TObject);
 begin
   OnShow := nil;
 {$IFDEF MSWINDOWS}
   if not TOSVersion.Check(6, 2) then // Windows 8
   begin
-    ShowMessage('This demo is designed to show Notification feature in Windows 8 or higher. Bye.');
+    ShowMessage
+      ('This demo is designed to show Notification feature in Windows 8 or higher. Bye.');
     Application.Terminate;
   end;
 {$ENDIF MSWINDOWS}
@@ -109,7 +124,8 @@ begin
   NotificationCenter1.CancelNotification('Windows10Notification');
 end;
 
-procedure TNotify.NotificationCenter1ReceiveLocalNotification(Sender: TObject; ANotification: TNotification);
+procedure TNotify.NotificationCenter1ReceiveLocalNotification(Sender: TObject;
+  ANotification: TNotification);
 begin
   mmLog.Lines.Add('Notification received: ' + ANotification.Name);
 end;

--- a/Object Pascal/VCL/Windows 10 Notifications/Notifications.dfm
+++ b/Object Pascal/VCL/Windows 10 Notifications/Notifications.dfm
@@ -10,9 +10,8 @@ object NotificationsForm: TNotificationsForm
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  OldCreateOrder = False
+  OnCreate = FormCreate
   OnShow = FormShow
-  PixelsPerInch = 96
   TextHeight = 13
   object mmLog: TMemo
     Left = 24

--- a/Object Pascal/VCL/Windows 10 Notifications/Notifications.pas
+++ b/Object Pascal/VCL/Windows 10 Notifications/Notifications.pas
@@ -1,4 +1,4 @@
-//---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 
 // This software is Copyright (c) 2015 Embarcadero Technologies, Inc.
 // You may only use this software if you are an authorized licensee
@@ -7,14 +7,15 @@
 // the software license agreement that comes with the Embarcadero Products
 // and is subject to that software license agreement.
 
-//---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 
 unit Notifications;
 
 interface
 
 uses
-  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
+  Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants,
+  System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, System.Notification, Vcl.StdCtrls;
 
 type
@@ -34,6 +35,7 @@ type
     procedure btnShowAnotherClick(Sender: TObject);
     procedure btnCancelAnotherClick(Sender: TObject);
     procedure FormShow(Sender: TObject);
+    procedure FormCreate(Sender: TObject);
   private
     { Private declarations }
   public
@@ -94,6 +96,15 @@ begin
   end;
 end;
 
+procedure TNotificationsForm.FormCreate(Sender: TObject);
+begin
+{$IFDEF MSWINDOWS}
+  // Windows needs a delay (some seconds) between initialization and presenting
+  // a notification to have the good title in first notification displayed in
+  // the life of a program
+  NotificationCenter1.PlatformInitialize;
+{$ENDIF}
+end;
 
 procedure TNotificationsForm.FormShow(Sender: TObject);
 begin
@@ -101,14 +112,15 @@ begin
 {$IFDEF MSWINDOWS}
   if not TOSVersion.Check(6, 2) then // Windows 8
   begin
-    ShowMessage('This demo is designed to show Notification feature in Windows 8 or higher. Bye.');
+    ShowMessage
+      ('This demo is designed to show Notification feature in Windows 8 or higher. Bye.');
     Application.Terminate;
   end;
 {$ENDIF MSWINDOWS}
 end;
 
-procedure TNotificationsForm.NotificationCenter1ReceiveLocalNotification(Sender: TObject;
-  ANotification: TNotification);
+procedure TNotificationsForm.NotificationCenter1ReceiveLocalNotification
+  (Sender: TObject; ANotification: TNotification);
 begin
   mmLog.Lines.Add('Notification received: ' + ANotification.Name);
 end;


### PR DESCRIPTION
To avoid the "embarcadero.delphitoasts.xxxxx" the first time we launch a notification in a program life on a Windows user session we need to call PlatformInitialisation on the TNotificationCenter instance.

Just added if on samples for VCL+FMX and more filters in gitignore to eliminate compiler folders when we list changes files to commit.